### PR TITLE
refactor: 상품 상세 페이지 컴포넌트 분리 및 더미 데이터 적용

### DIFF
--- a/src/app/_components/productDetail/ProductDescription.tsx
+++ b/src/app/_components/productDetail/ProductDescription.tsx
@@ -1,0 +1,9 @@
+const ProductDescription = () => {
+  return (
+    <section className="flex items-center w-full max-w-6xl gap-4 p-4">
+      <p>작성자가 작성한 설명</p>
+    </section>
+  );
+};
+
+export default ProductDescription;

--- a/src/app/_components/productDetail/ProductDescription.tsx
+++ b/src/app/_components/productDetail/ProductDescription.tsx
@@ -1,7 +1,11 @@
-const ProductDescription = () => {
+interface ProductDescriptionProps {
+  description: string;
+}
+
+const ProductDescription = ({ description }: ProductDescriptionProps) => {
   return (
     <section className="flex items-center w-full max-w-6xl gap-4 p-4">
-      <p>작성자가 작성한 설명</p>
+      <p>{description}</p>
     </section>
   );
 };

--- a/src/app/_components/productDetail/ProductGallery.tsx
+++ b/src/app/_components/productDetail/ProductGallery.tsx
@@ -1,15 +1,13 @@
 import Image from "next/image";
 import { useState } from "react";
 
-const imageList = [
-  "/images/cat-5183427_1280.jpg",
-  "/images/cat-84621142.jpeg",
-  "/images/cat-birthday_cat_sad.jpg",
-];
+interface ProductGalleryProps {
+  images: string[];
+}
 
-const ProductGallery = () => {
+const ProductGallery = ({ images }: ProductGalleryProps) => {
   // 현재 표시할 메인 이미지를 관리할 상태
-  const [currentImage, setCurrentImage] = useState(imageList[0]);
+  const [currentImage, setCurrentImage] = useState(images[0]);
 
   // 이미지 전환 애니메이션을 위한 상태
   const [opacity, setOpacity] = useState(1);
@@ -27,7 +25,7 @@ const ProductGallery = () => {
     <section className="flex gap-4 w-3/5">
       {/* 썸네일 이미지 */}
       <div className="flex flex-col gap-4 basis-1/5 relative">
-        {imageList.map((src, index) => (
+        {images.map((src, index) => (
           <div
             key={index}
             onClick={() => changeImage(src)}

--- a/src/app/_components/productDetail/ProductGallery.tsx
+++ b/src/app/_components/productDetail/ProductGallery.tsx
@@ -1,0 +1,59 @@
+import Image from "next/image";
+import { useState } from "react";
+
+const imageList = [
+  "/images/cat-5183427_1280.jpg",
+  "/images/cat-84621142.jpeg",
+  "/images/cat-birthday_cat_sad.jpg",
+];
+
+const ProductGallery = () => {
+  // 현재 표시할 메인 이미지를 관리할 상태
+  const [currentImage, setCurrentImage] = useState(imageList[0]);
+
+  // 이미지 전환 애니메이션을 위한 상태
+  const [opacity, setOpacity] = useState(1);
+
+  // 이미지 전환 애니메이션 적용 - 바로 이미지가 바뀌면 부자연스러우니까 0.5초 후에 변경, 서서히 나타남
+  const changeImage = (src: string) => {
+    setOpacity(0);
+    setTimeout(() => {
+      setCurrentImage(src);
+      setOpacity(1);
+    }, 500);
+  };
+
+  return (
+    <section className="flex gap-4 w-3/5">
+      {/* 썸네일 이미지 */}
+      <div className="flex flex-col gap-4 basis-1/5 relative">
+        {imageList.map((src, index) => (
+          <div
+            key={index}
+            onClick={() => changeImage(src)}
+            className="relative  w-full h-[100px] cursor-pointer transform transition-transform duration-300 hover:scale-110 active:brightness-75"
+          >
+            <Image src={src} alt="" layout="fill" objectFit="cover" />
+          </div>
+        ))}
+      </div>
+      {/* 메인 이미지 */}
+      <div
+        className={`relative flex-1 h-[480px] transition-opacity duration-300 ease-in-out ${
+          opacity === 1 ? "opacity-100" : "opacity-0"
+        }`}
+      >
+        <Image
+          src={currentImage}
+          alt=""
+          // width={800}
+          // height={480}
+          layout="fill"
+          objectFit="cover"
+        />
+      </div>
+    </section>
+  );
+};
+
+export default ProductGallery;

--- a/src/app/_components/productDetail/ProductInfo.tsx
+++ b/src/app/_components/productDetail/ProductInfo.tsx
@@ -1,36 +1,49 @@
-const ProductInfo = () => {
+interface ProductInfoProps {
+  product: Product;
+}
+
+type Product = {
+  grade: string; // 상품등급
+  name: string; // 상품명
+  category: string; // 카테고리
+  startingPrice: number; // 시작가
+  currentPrice: number; // 현재가
+  closingTime: string; // 마감시간
+};
+
+const ProductInfo = ({ product }: ProductInfoProps) => {
   return (
     <section className="flex flex-col w-2/5 space-y-4 p-4">
       {/* 상품등급, 상품명, 카테고리, 시작가, 현재가, 마감시간, 남은 시간 */}
       <div>
-        <span className="text-gray-600 font-medium">상품등급</span>
-        <h2 className="text-2xl font-bold mb-4">상품명</h2>
+        <span className="text-gray-600 font-medium">{product.grade}급</span>
+        <h2 className="text-2xl font-bold mb-4">{product.name}</h2>
 
         <ul className="space-y-2">
           <li className="flex gap-8 items-center">
             <label htmlFor="category" className="font-medium">
               카테고리:
             </label>
-            <span>신발</span>
+            <span>{product.category}</span>
           </li>
           <hr />
           <li className="flex gap-8 items-center">
             <label htmlFor="starting-price" className="font-medium">
               시작가:
             </label>
-            <span>100,000원</span>
+            <span>{product.startingPrice}원</span>
           </li>
           <li className="flex gap-8 items-center">
             <label htmlFor="current-price" className="font-medium">
               현재가:
             </label>
-            <span>120,000원</span>
+            <span>{product.currentPrice}원</span>
           </li>
           <li className="flex gap-8 items-center">
             <label htmlFor="closing-time" className="font-medium">
               마감시간:
             </label>
-            <span>2024년 5월 15일 18시</span>
+            <span>{product.closingTime}</span>
           </li>
           <li className="flex gap-8 items-center justify-center">
             <span>3일 12시간 5분 </span>

--- a/src/app/_components/productDetail/ProductInfo.tsx
+++ b/src/app/_components/productDetail/ProductInfo.tsx
@@ -1,0 +1,47 @@
+const ProductInfo = () => {
+  return (
+    <section className="flex flex-col w-2/5 space-y-4 p-4">
+      {/* 상품등급, 상품명, 카테고리, 시작가, 현재가, 마감시간, 남은 시간 */}
+      <div>
+        <span className="text-gray-600 font-medium">상품등급</span>
+        <h2 className="text-2xl font-bold mb-4">상품명</h2>
+
+        <ul className="space-y-2">
+          <li className="flex gap-8 items-center">
+            <label htmlFor="category" className="font-medium">
+              카테고리:
+            </label>
+            <span>신발</span>
+          </li>
+          <hr />
+          <li className="flex gap-8 items-center">
+            <label htmlFor="starting-price" className="font-medium">
+              시작가:
+            </label>
+            <span>100,000원</span>
+          </li>
+          <li className="flex gap-8 items-center">
+            <label htmlFor="current-price" className="font-medium">
+              현재가:
+            </label>
+            <span>120,000원</span>
+          </li>
+          <li className="flex gap-8 items-center">
+            <label htmlFor="closing-time" className="font-medium">
+              마감시간:
+            </label>
+            <span>2024년 5월 15일 18시</span>
+          </li>
+          <li className="flex gap-8 items-center justify-center">
+            <span>3일 12시간 5분 </span>
+            <button className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md">
+              입찰하기
+            </button>
+          </li>
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default ProductInfo;

--- a/src/app/_components/productDetail/ProductNotice.tsx
+++ b/src/app/_components/productDetail/ProductNotice.tsx
@@ -1,7 +1,11 @@
-const ProductNotice = () => {
+interface ProductNoticeProps {
+  content: string;
+}
+
+const ProductNotice = ({ content }: ProductNoticeProps) => {
   return (
     <section className="flex items-center w-full max-w-6xl gap-4 p-4">
-      <p>주의사항 안내</p>
+      <p>{content}</p>
     </section>
   );
 };

--- a/src/app/_components/productDetail/ProductNotice.tsx
+++ b/src/app/_components/productDetail/ProductNotice.tsx
@@ -1,0 +1,9 @@
+const ProductNotice = () => {
+  return (
+    <section className="flex items-center w-full max-w-6xl gap-4 p-4">
+      <p>주의사항 안내</p>
+    </section>
+  );
+};
+
+export default ProductNotice;

--- a/src/app/_components/productDetail/ProductSellerInfo.tsx
+++ b/src/app/_components/productDetail/ProductSellerInfo.tsx
@@ -1,18 +1,28 @@
 import Image from "next/image";
 
-const ProductSellerInfo = () => {
+interface ProductSellerInfoProps {
+  seller: Seller;
+}
+
+type Seller = {
+  profileImage: string; // 작성자 프로필 이미지
+  nickname: string; // 작성자 닉네임
+  content: string; // 작성자 소개글
+};
+
+const ProductSellerInfo = ({ seller }: ProductSellerInfoProps) => {
   return (
     <section className="flex items-center w-full max-w-6xl gap-4 p-4">
       {/* 작성자 프로필 이미지, 작성자 닉네임, 작성자 소개글 */}
       <Image
-        src="/images/cat-5183427_1280.jpg"
+        src={seller.profileImage}
         alt=""
         width={100}
         height={100}
         className="rounded-full"
       />
-      <h3>작성자 닉네임</h3>
-      <p>작성자 소개글</p>
+      <h3>{seller.nickname}</h3>
+      <p>{seller.content}</p>
     </section>
   );
 };

--- a/src/app/_components/productDetail/ProductSellerInfo.tsx
+++ b/src/app/_components/productDetail/ProductSellerInfo.tsx
@@ -1,0 +1,20 @@
+import Image from "next/image";
+
+const ProductSellerInfo = () => {
+  return (
+    <section className="flex items-center w-full max-w-6xl gap-4 p-4">
+      {/* 작성자 프로필 이미지, 작성자 닉네임, 작성자 소개글 */}
+      <Image
+        src="/images/cat-5183427_1280.jpg"
+        alt=""
+        width={100}
+        height={100}
+        className="rounded-full"
+      />
+      <h3>작성자 닉네임</h3>
+      <p>작성자 소개글</p>
+    </section>
+  );
+};
+
+export default ProductSellerInfo;

--- a/src/app/productList/[id]/page.tsx
+++ b/src/app/productList/[id]/page.tsx
@@ -6,18 +6,25 @@ import ProductInfo from "@/app/_components/productDetail/ProductInfo";
 import ProductNotice from "@/app/_components/productDetail/ProductNotice";
 import ProductSellerInfo from "@/app/_components/productDetail/ProductSellerInfo";
 
-const imageList = [
-  "/images/cat-5183427_1280.jpg",
-  "/images/cat-84621142.jpeg",
-  "/images/cat-birthday_cat_sad.jpg",
-];
+const dummyProductDetail = {
+  images: [
+    "/images/cat-5183427_1280.jpg",
+    "/images/cat-84621142.jpeg",
+    "/images/cat-birthday_cat_sad.jpg",
+  ],
+  product: {
+    description: "작성자가 작성한 설명 - Product Detail",
+  },
+  seller: {},
+  notice: "주의사항 안내 \n - Product Detail ",
+};
 
 const ProductDetail = () => {
   return (
     <main className="flex flex-col items-center p-8 space-y-8">
       <div className="flex w-full max-w-6xl gap-8">
         {/* 이미지 갤러리 섹션 */}
-        <ProductGallery images={imageList} />
+        <ProductGallery images={dummyProductDetail.images} />
         {/* 상품 정보 섹션 */}
         <ProductInfo />
       </div>
@@ -26,10 +33,12 @@ const ProductDetail = () => {
       <ProductSellerInfo />
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 상품 설명 섹션 */}
-      <ProductDescription />
+      <ProductDescription
+        description={dummyProductDetail.product.description}
+      />
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 주의사항 안내 섹션 */}
-      <ProductNotice />
+      <ProductNotice content={dummyProductDetail.notice} />
       <hr className="w-full max-w-6xl border-t-2" />
     </main>
   );

--- a/src/app/productList/[id]/page.tsx
+++ b/src/app/productList/[id]/page.tsx
@@ -13,6 +13,12 @@ const dummyProductDetail = {
     "/images/cat-birthday_cat_sad.jpg",
   ],
   product: {
+    grade: "S",
+    name: "나이키 에어 맥스",
+    category: "신발",
+    startingPrice: 120000,
+    currentPrice: 135000,
+    closingTime: "2024-05-15T18:00:00Z",
     description: "작성자가 작성한 설명 - Product Detail",
   },
   seller: {
@@ -30,7 +36,7 @@ const ProductDetail = () => {
         {/* 이미지 갤러리 섹션 */}
         <ProductGallery images={dummyProductDetail.images} />
         {/* 상품 정보 섹션 */}
-        <ProductInfo />
+        <ProductInfo product={dummyProductDetail.product} />
       </div>
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 작성자 정보 섹션 */}

--- a/src/app/productList/[id]/page.tsx
+++ b/src/app/productList/[id]/page.tsx
@@ -1,130 +1,29 @@
 "use client";
 
-import Image from "next/image";
-import { useState } from "react";
-
-const imageList = [
-  "/images/cat-5183427_1280.jpg",
-  "/images/cat-84621142.jpeg",
-  "/images/cat-birthday_cat_sad.jpg",
-];
+import ProductDescription from "@/app/_components/productDetail/ProductDescription";
+import ProductGallery from "@/app/_components/productDetail/ProductGallery";
+import ProductInfo from "@/app/_components/productDetail/ProductInfo";
+import ProductNotice from "@/app/_components/productDetail/ProductNotice";
+import ProductSellerInfo from "@/app/_components/productDetail/ProductSellerInfo";
 
 const ProductDetail = () => {
-  // 현재 표시할 메인 이미지를 관리할 상태
-  const [currentImage, setCurrentImage] = useState(imageList[0]);
-
-  // 이미지 전환 애니메이션을 위한 상태
-  const [opacity, setOpacity] = useState(1);
-
-  // 이미지 전환 애니메이션 적용 - 바로 이미지가 바뀌면 부자연스러우니까 0.5초 후에 변경, 서서히 나타남
-  const changeImage = (src: string) => {
-    setOpacity(0);
-    setTimeout(() => {
-      setCurrentImage(src);
-      setOpacity(1);
-    }, 500);
-  };
-
   return (
     <main className="flex flex-col items-center p-8 space-y-8">
       <div className="flex w-full max-w-6xl gap-8">
         {/* 이미지 갤러리 섹션 */}
-        <section className="flex gap-4 w-3/5">
-          {/* 썸네일 이미지 */}
-          <div className="flex flex-col gap-4 basis-1/5 relative">
-            {imageList.map((src, index) => (
-              <div
-                key={index}
-                onClick={() => changeImage(src)}
-                className="relative  w-full h-[100px] cursor-pointer transform transition-transform duration-300 hover:scale-110 active:brightness-75"
-              >
-                <Image src={src} alt="" layout="fill" objectFit="cover" />
-              </div>
-            ))}
-          </div>
-          {/* 메인 이미지 */}
-          <div
-            className={`relative flex-1 h-[480px] transition-opacity duration-300 ease-in-out ${
-              opacity === 1 ? "opacity-100" : "opacity-0"
-            }`}
-          >
-            <Image
-              src={currentImage}
-              alt=""
-              // width={800}
-              // height={480}
-              layout="fill"
-              objectFit="cover"
-            />
-          </div>
-        </section>
+        <ProductGallery />
         {/* 상품 정보 섹션 */}
-        <section className="flex flex-col w-2/5 space-y-4 p-4">
-          {/* 상품등급, 상품명, 카테고리, 시작가, 현재가, 마감시간, 남은 시간 */}
-          <div>
-            <span className="text-gray-600 font-medium">상품등급</span>
-            <h2 className="text-2xl font-bold mb-4">상품명</h2>
-
-            <ul className="space-y-2">
-              <li className="flex gap-8 items-center">
-                <label htmlFor="category" className="font-medium">
-                  카테고리:
-                </label>
-                <span>신발</span>
-              </li>
-              <hr />
-              <li className="flex gap-8 items-center">
-                <label htmlFor="starting-price" className="font-medium">
-                  시작가:
-                </label>
-                <span>100,000원</span>
-              </li>
-              <li className="flex gap-8 items-center">
-                <label htmlFor="current-price" className="font-medium">
-                  현재가:
-                </label>
-                <span>120,000원</span>
-              </li>
-              <li className="flex gap-8 items-center">
-                <label htmlFor="closing-time" className="font-medium">
-                  마감시간:
-                </label>
-                <span>2024년 5월 15일 18시</span>
-              </li>
-              <li className="flex gap-8 items-center justify-center">
-                <span>3일 12시간 5분 </span>
-                <button className="mt-4 px-4 py-2 bg-blue-500 text-white rounded-md">
-                  입찰하기
-                </button>
-              </li>
-            </ul>
-          </div>
-        </section>
+        <ProductInfo />
       </div>
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 작성자 정보 섹션 */}
-      <section className="flex items-center w-full max-w-6xl gap-4 p-4">
-        {/* 작성자 프로필 이미지, 작성자 닉네임, 작성자 소개글 */}
-        <Image
-          src="/images/cat-5183427_1280.jpg"
-          alt=""
-          width={100}
-          height={100}
-          className="rounded-full"
-        />
-        <h3>작성자 닉네임</h3>
-        <p>작성자 소개글</p>
-      </section>
+      <ProductSellerInfo />
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 상품 설명 섹션 */}
-      <section className="flex items-center w-full max-w-6xl gap-4 p-4">
-        <p>작성자가 작성한 설명</p>
-      </section>
+      <ProductDescription />
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 주의사항 안내 섹션 */}
-      <section className="flex items-center w-full max-w-6xl gap-4 p-4">
-        <p>주의사항 안내</p>
-      </section>
+      <ProductNotice />
       <hr className="w-full max-w-6xl border-t-2" />
     </main>
   );

--- a/src/app/productList/[id]/page.tsx
+++ b/src/app/productList/[id]/page.tsx
@@ -6,12 +6,18 @@ import ProductInfo from "@/app/_components/productDetail/ProductInfo";
 import ProductNotice from "@/app/_components/productDetail/ProductNotice";
 import ProductSellerInfo from "@/app/_components/productDetail/ProductSellerInfo";
 
+const imageList = [
+  "/images/cat-5183427_1280.jpg",
+  "/images/cat-84621142.jpeg",
+  "/images/cat-birthday_cat_sad.jpg",
+];
+
 const ProductDetail = () => {
   return (
     <main className="flex flex-col items-center p-8 space-y-8">
       <div className="flex w-full max-w-6xl gap-8">
         {/* 이미지 갤러리 섹션 */}
-        <ProductGallery />
+        <ProductGallery images={imageList} />
         {/* 상품 정보 섹션 */}
         <ProductInfo />
       </div>

--- a/src/app/productList/[id]/page.tsx
+++ b/src/app/productList/[id]/page.tsx
@@ -15,7 +15,11 @@ const dummyProductDetail = {
   product: {
     description: "작성자가 작성한 설명 - Product Detail",
   },
-  seller: {},
+  seller: {
+    nickname: "고양이 바니",
+    content: "츄르를 좋아합니다.",
+    profileImage: "/images/cat-84621142.jpeg", //
+  },
   notice: "주의사항 안내 \n - Product Detail ",
 };
 
@@ -30,7 +34,7 @@ const ProductDetail = () => {
       </div>
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 작성자 정보 섹션 */}
-      <ProductSellerInfo />
+      <ProductSellerInfo seller={dummyProductDetail.seller} />
       <hr className="w-full max-w-6xl border-t-2" />
       {/* 상품 설명 섹션 */}
       <ProductDescription


### PR DESCRIPTION
## 변경사항
- 상품 상세 페이지 컴포넌트 분리 
> `ProductGallery`, `ProductInfo`, `SellerInfo`, `ProductDescription`, `ProductNotice` 컴포넌트로 분리
- 더미 데이터 적용
> 임시DB모델링 토대로 통합된 더미데이터 객체 만듦
> dummyProductDetail -> images, product, seller, notice

## 변경이유
- 한 컴포넌트에 긴 html 코드들이 있어서 가독성 떨어지므로 분리
- 상수로 적어놓은 텍스트들을 임의로 작성한 더미데이터로 동적 처리 되도록 개선

